### PR TITLE
feat(azure): add azure support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Azure Carbon Emissions Configuration
+CARBEM_AZURE_ACCESS_TOKEN=your_azure_bearer_token_here

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,22 +3,23 @@ name = "carbem"
 version = "0.1.0"
 edition = "2021"
 description = "A Rust library for retrieving carbon emission values from cloud providers"
-authors = ["Your Name <your.email@example.com>"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/yourusername/carbem"
+authors = ["Jonathan Perron <jonathan@perron.bzh>"]
+license = "Apache-2.0"
+repository = "https://github.com/jonperron/carbem"
 keywords = ["carbon", "emissions", "cloud", "sustainability", "environment"]
 categories = ["api-bindings", "web-programming"]
 readme = "README.md"
 
 [dependencies]
 tokio = { version = "1.0", features = ["full"] }
-reqwest = { version = "0.11", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
+reqwest = { version = "0.12.23", features = ["json"] }
+serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-thiserror = "1.0"
+thiserror = "2.0.16"
 anyhow = "1.0"
 async-trait = "0.1"
+dotenv = "0.15"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -24,15 +24,124 @@ carbem = "0.1.0"
 
 ## Quick Start
 
+### Python FFI Compatible API (Recommended)
+
+The library provides a simple 3-parameter function designed for easy Python integration:
+
+```rust
+use carbem::get_emissions;
+
+#[tokio::main]
+async fn main() -> carbem::Result<()> {
+    // JSON configuration for Azure
+    let config_json = r#"{
+        "subscription_ids": ["00000000-0000-0000-0000-000000000000"],
+        "access_token": "your_azure_bearer_token_here",
+        "tenant_id": "your_tenant_id_here",
+        "report_type": "monthly"
+    }"#;
+    
+    // JSON payload for the query
+    let payload_json = r#"{
+        "start_date": "2024-01-01T00:00:00Z",
+        "end_date": "2024-02-01T00:00:00Z",
+        "regions": ["eastus", "westus"],
+        "services": null,
+        "resources": null
+    }"#;
+    
+    // Simple function call - perfect for Python FFI
+    let emissions = get_emissions("azure", config_json, payload_json).await?;
+    
+    for emission in emissions {
+        println!("Service: {}, Emissions: {} kg CO2eq", 
+                 emission.service.unwrap_or_default(),
+                 emission.emissions_kg_co2eq);
+    }
+    
+    Ok(())
+}
+```
+
+### Standalone Rust API
+
+For standalone Rust applications, use environment variables:
+
 ```rust
 use carbem::CarbemClient;
 
 #[tokio::main]
 async fn main() -> carbem::Result<()> {
-    let client = CarbemClient::new();
+    // Automatically loads from .env file and environment variables
+    let client = CarbemClient::from_env()?;
     
-    // Usage examples will be added as providers are implemented
-    // let emissions = client.get_emissions("aws", region, timeframe).await?;
+    // Simple query with sensible defaults
+    let emissions = client.query_emissions(
+        None, // start_date: defaults to 30 days ago
+        None, // end_date: defaults to now  
+        None, // regions: use all available regions
+        None, // services: no filter
+        None, // resources: no filter
+    ).await?;
+    
+    for emission in emissions {
+        println!("Service: {}, Emissions: {} kg CO2eq", 
+                 emission.service.unwrap_or_default(),
+                 emission.emissions_kg_co2eq);
+    }
+    
+    Ok(())
+}
+```
+
+Create a `.env` file in your project root:
+
+```env
+# Azure Carbon Emissions Configuration
+CARBEM_AZURE_ACCESS_TOKEN=your_azure_bearer_token_here
+```
+
+## Configuration Parameters
+
+### Environment Variables (for Standalone Rust)
+
+- `CARBEM_AZURE_ACCESS_TOKEN`: Azure access token
+
+### Object-Oriented API (Advanced Usage)
+
+```rust
+use carbem::{CarbemClient, AzureConfig, EmissionQuery, TimePeriod};
+use chrono::{Utc, Duration};
+
+#[tokio::main]
+async fn main() -> carbem::Result<()> {
+    // Create a client and configure Azure provider
+    let mut client = CarbemClient::new();
+    
+    let config = AzureConfig {
+        access_token: "your-bearer-token".to_string(),
+    };
+    
+    client.set_azure_provider(config)?;
+    
+    // Query carbon emissions for the last 30 days
+    let query = EmissionQuery {
+        provider: "azure".to_string(),
+        regions: vec![], // Use all available regions
+        time_period: TimePeriod {
+            start: Utc::now() - Duration::days(30),
+            end: Utc::now(),
+        },
+    };
+    
+    let emissions = client.get_emissions(query).await?;
+    
+    for emission in emissions {
+        println!("Date: {}, Region: {}, Emissions: {} kg CO2eq", 
+                 emission.time_period.start.format("%Y-%m-%d"),
+                 emission.region, 
+                 emission.emissions_kg_co2eq);
+    }
     
     Ok(())
 }
@@ -40,11 +149,52 @@ async fn main() -> carbem::Result<()> {
 
 ## Supported Providers
 
-*This section will be updated as cloud providers are implemented:*
+### Microsoft Azure ✅
+
+- **Carbon Emission Reports API**: Integrated with Azure's Carbon Emission Reports API
+- **Multiple Report Types**: Support for Overall Summary and Monthly Summary reports
+- **Flexible Date Ranges**: Query emissions for custom time periods
+- **Region Filtering**: Filter results by specific Azure regions
+- **Comprehensive Testing**: Full test suite ensuring reliability
+
+### Planned Providers
+
+- [ ] Amazon Web Services (AWS)
+- [ ] Google Cloud Platform (GCP)
+- [ ] Additional providers planned
 
 ## Roadmap
 
-- [ ] Core library infrastructure
+- [x] Core library infrastructure
+- [x] Azure Carbon Emission Reports API integration
+- [x] Python FFI compatible API design
+- [x] Environment-based configuration
+- [ ] Additional Azure report types (TopItems, ItemDetails)
+- [ ] AWS provider implementation
+- [ ] Google Cloud Platform provider
+
+## Testing
+
+The library includes a comprehensive test suite:
+
+```bash
+# Run all tests
+cargo test
+
+# Run specific Azure provider tests
+cargo test providers::azure
+
+# Run with output
+cargo test -- --nocapture
+```
+
+Test coverage includes:
+
+- Provider creation and configuration
+- Query conversion and validation
+- Date parsing and time period handling
+- Data conversion from Azure API responses  
+- Error handling for invalid configurations
 
 ## Contributing
 
@@ -52,11 +202,9 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## License
 
-This project is licensed under either of
-
-- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-
+This project is licensed under Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 ## Acknowledgments
 
 This project aims to support sustainability efforts in cloud computing by making carbon emission data more accessible to developers and organizations.
+

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,45 +1,169 @@
-use crate::{Result, CarbonEmission, EmissionQuery};
-use reqwest::Client;
-use std::time::Duration;
+use crate::error::{CarbemError, Result};
+use crate::models::{CarbonEmission, EmissionQuery, TimePeriod};
+use crate::providers::azure::client::{AzureConfig, AzureProvider};
+use crate::providers::azure::models::AzureReportType;
+use crate::providers::CarbonProvider;
+use std::env;
 
-/// The main client for interacting with carbon emission data providers
-#[derive(Debug, Clone)]
 pub struct CarbemClient {
-    http_client: Client,
+    azure_provider: Option<AzureProvider>,
+}
+
+pub async fn get_emissions(
+    provider: &str,
+    json_config: &str,
+    json_payload: &str,
+) -> Result<Vec<CarbonEmission>> {
+    match provider.to_lowercase().as_str() {
+        "azure" => get_azure_emissions_from_json(json_config, json_payload).await,
+        _ => Err(CarbemError::UnsupportedProvider(provider.to_string())),
+    }
+}
+
+pub async fn get_azure_emissions_from_json(
+    json_config: &str,
+    json_payload: &str,
+) -> Result<Vec<CarbonEmission>> {
+    #[derive(serde::Deserialize)]
+    struct AzureConfigJson {
+        subscription_ids: Vec<String>,
+        access_token: String,
+        tenant_id: Option<String>,
+        report_type: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct QueryPayload {
+        start_date: Option<String>,
+        end_date: Option<String>,
+        regions: Option<Vec<String>>,
+        services: Option<Vec<String>>,
+        resources: Option<Vec<String>>,
+    }
+
+    let config_json: AzureConfigJson = serde_json::from_str(json_config)
+        .map_err(|e| CarbemError::ConfigError(format!("Invalid config JSON: {}", e)))?;
+
+    let payload: QueryPayload = serde_json::from_str(json_payload)
+        .map_err(|e| CarbemError::ConfigError(format!("Invalid payload JSON: {}", e)))?;
+
+    let report_type = match config_json.report_type.as_deref().unwrap_or("overall") {
+        "overall" => AzureReportType::OverallSummary,
+        "monthly" => AzureReportType::MonthlySummary,
+        _ => AzureReportType::OverallSummary,
+    };
+
+    let config = AzureConfig {
+        access_token: config_json.access_token,
+    };
+
+    let provider = AzureProvider::new(config)?;
+
+    let start_date = payload
+        .start_date
+        .as_ref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|| chrono::Utc::now() - chrono::Duration::days(30));
+
+    let end_date = payload
+        .end_date
+        .as_ref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|| chrono::Utc::now());
+
+    let query = EmissionQuery {
+        provider: "azure".to_string(),
+        regions: payload.regions.unwrap_or_default(),
+        time_period: TimePeriod {
+            start: start_date,
+            end: end_date,
+        },
+    };
+
+    provider.get_emissions(&query).await
 }
 
 impl CarbemClient {
-    /// Create a new CarbemClient with default configuration
     pub fn new() -> Self {
-        let http_client = Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .expect("Failed to create HTTP client");
-        
-        Self { http_client }
+        Self {
+            azure_provider: None,
+        }
     }
-    
-    /// Create a new CarbemClient with custom HTTP client
-    pub fn with_client(http_client: Client) -> Self {
-        Self { http_client }
+
+    pub fn from_env() -> Result<Self> {
+        let _ = dotenv::dotenv();
+        let mut client = Self::new();
+        client.load_azure_from_env()?;
+        Ok(client)
     }
-    
-    /// Query carbon emissions from a specific provider
+
+    pub fn load_azure_from_env(&mut self) -> Result<()> {
+        let subscription_ids_str = env::var("CARBEM_AZURE_SUBSCRIPTION_IDS").map_err(|_| {
+            CarbemError::ConfigError(
+                "CARBEM_AZURE_SUBSCRIPTION_IDS environment variable not set".to_string(),
+            )
+        })?;
+
+        let subscription_ids: Vec<String> = subscription_ids_str
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect();
+
+        let access_token = env::var("CARBEM_AZURE_ACCESS_TOKEN").map_err(|_| {
+            CarbemError::ConfigError(
+                "CARBEM_AZURE_ACCESS_TOKEN environment variable not set".to_string(),
+            )
+        })?;
+
+        let config = AzureConfig { access_token };
+
+        self.set_azure_provider(config)
+    }
+
+    pub fn set_azure_provider(&mut self, config: AzureConfig) -> Result<()> {
+        let provider = AzureProvider::new(config)?;
+        self.azure_provider = Some(provider);
+        Ok(())
+    }
+
     pub async fn get_emissions(&self, query: EmissionQuery) -> Result<Vec<CarbonEmission>> {
-        // This method will be implemented when specific providers are added
-        todo!("Implementation will be added when providers are implemented")
+        match query.provider.as_str() {
+            "azure" => {
+                if let Some(provider) = &self.azure_provider {
+                    provider.get_emissions(&query).await
+                } else {
+                    Err(CarbemError::Config(
+                        "No Azure provider configured".to_string(),
+                    ))
+                }
+            }
+            _ => Err(CarbemError::Provider(format!(
+                "Unsupported provider: {}",
+                query.provider
+            ))),
+        }
     }
-    
-    /// Get available providers
-    pub fn get_supported_providers(&self) -> Vec<&'static str> {
-        // Will be updated as providers are implemented
-        vec![]
-    }
-    
-    /// Get available regions for a provider
-    pub async fn get_regions(&self, provider: &str) -> Result<Vec<String>> {
-        // This method will be implemented when specific providers are added
-        todo!("Implementation will be added when providers are implemented")
+
+    pub async fn query_emissions(
+        &self,
+        start_date: Option<chrono::DateTime<chrono::Utc>>,
+        end_date: Option<chrono::DateTime<chrono::Utc>>,
+        regions: Option<Vec<String>>,
+        services: Option<Vec<String>>,
+        resources: Option<Vec<String>>,
+    ) -> Result<Vec<CarbonEmission>> {
+        let start = start_date.unwrap_or_else(|| chrono::Utc::now() - chrono::Duration::days(30));
+        let end = end_date.unwrap_or_else(|| chrono::Utc::now());
+
+        let query = EmissionQuery {
+            provider: "azure".to_string(),
+            regions: regions.unwrap_or_default(),
+            time_period: TimePeriod { start, end },
+        };
+
+        self.get_emissions(query).await
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,27 +6,35 @@ pub enum CarbemError {
     /// HTTP request failed
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
-    
+
     /// JSON serialization/deserialization error
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
-    
+
     /// Provider-specific error
     #[error("Provider error: {0}")]
     Provider(String),
-    
+
+    /// Unsupported provider
+    #[error("Unsupported provider: {0}")]
+    UnsupportedProvider(String),
+
     /// Invalid configuration
     #[error("Invalid configuration: {0}")]
     Config(String),
-    
+
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+
     /// Authentication error
     #[error("Authentication failed: {0}")]
     Auth(String),
-    
+
     /// Rate limit exceeded
     #[error("Rate limit exceeded")]
     RateLimit,
-    
+
     /// Generic error
     #[error("An error occurred: {0}")]
     Other(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,15 @@
 //! # Carbem
-//! 
+//!
 //! A Rust library for retrieving carbon emission values from cloud providers.
-//! 
+//!
 //! This library provides a unified interface for querying carbon emission data
 //! from various cloud service providers, helping developers build more
 //! environmentally conscious applications.
 
+pub mod client;
 pub mod error;
 pub mod models;
 pub mod providers;
-pub mod client;
 
-pub use error::{CarbemError, Result};
-pub use models::*;
-pub use client::CarbemClient;
-
-/// The main entry point for the Carbem library.
-/// 
-/// # Examples
-/// 
-/// ```rust
-/// use carbem::CarbemClient;
-/// 
-/// #[tokio::main]
-/// async fn main() -> carbem::Result<()> {
-///     let client = CarbemClient::new();
-///     // Usage examples will be added as providers are implemented
-///     Ok(())
-/// }
+// Only expose the client module - all other types are re-exported from there
+pub use client::*;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,24 +1,24 @@
-use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 /// Represents carbon emission data from a cloud provider
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CarbonEmission {
     /// The cloud provider (e.g., "aws", "azure", "gcp")
     pub provider: String,
-    
+
     /// The region where the emissions occurred
     pub region: String,
-    
+
     /// The service or resource type
     pub service: Option<String>,
-    
+
     /// Carbon emissions in kilograms of CO2 equivalent
     pub emissions_kg_co2eq: f64,
-    
+
     /// The time period for which emissions are reported
     pub time_period: TimePeriod,
-    
+
     /// Additional metadata
     pub metadata: Option<EmissionMetadata>,
 }
@@ -28,7 +28,7 @@ pub struct CarbonEmission {
 pub struct TimePeriod {
     /// Start of the measurement period
     pub start: DateTime<Utc>,
-    
+
     /// End of the measurement period
     pub end: DateTime<Utc>,
 }
@@ -36,16 +36,16 @@ pub struct TimePeriod {
 /// Additional metadata for carbon emissions
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmissionMetadata {
-    /// Energy consumption in kWh
+    // Energy consumption in kWh
     pub energy_kwh: Option<f64>,
-    
-    /// Grid carbon intensity (gCO2eq/kWh)
+
+    // Grid carbon intensity (gCO2eq/kWh)
     pub grid_carbon_intensity: Option<f64>,
-    
-    /// Renewable energy percentage
+
+    // Renewable energy percentage
     pub renewable_percentage: Option<f64>,
-    
-    /// Additional provider-specific data
+
+    // Additional provider-specific data
     pub provider_data: Option<serde_json::Value>,
 }
 
@@ -54,16 +54,10 @@ pub struct EmissionMetadata {
 pub struct EmissionQuery {
     /// The cloud provider to query
     pub provider: String,
-    
+
     /// The region(s) to include
     pub regions: Vec<String>,
-    
+
     /// The time period to query
     pub time_period: TimePeriod,
-    
-    /// Optional service filter
-    pub services: Option<Vec<String>>,
-    
-    /// Optional resource filter
-    pub resources: Option<Vec<String>>,
 }

--- a/src/providers/azure/client.rs
+++ b/src/providers/azure/client.rs
@@ -1,0 +1,724 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Datelike, TimeZone, Utc};
+use reqwest::{
+    header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE},
+    Client,
+};
+
+use crate::error::{CarbemError, Result};
+use crate::models::{CarbonEmission, EmissionMetadata, EmissionQuery, TimePeriod};
+use crate::providers::CarbonProvider;
+
+use super::models::*;
+
+// Azure Management API base URL
+const AZURE_MANAGEMENT_BASE_URL: &str = "https://management.azure.com";
+const CARBON_API_VERSION: &str = "2025-04-01";
+
+// Configuration for Azure provider
+#[derive(Debug, Clone)]
+pub struct AzureConfig {
+    pub access_token: String,
+}
+
+// Azure Carbon Optimization provider
+#[derive(Debug, Clone)]
+pub struct AzureProvider {
+    config: AzureConfig,
+    http_client: Client,
+}
+
+impl AzureProvider {
+    // Create a new Azure provider instance with configuration
+    pub fn new(config: AzureConfig) -> Result<Self> {
+        let http_client = Client::new();
+        Ok(Self {
+            config,
+            http_client,
+        })
+    }
+
+    // Convert EmissionQuery to Azure-specific request format
+    fn convert_emission_query_to_azure_request(
+        &self,
+        query: &EmissionQuery,
+    ) -> Result<AzureCarbonEmissionReportRequest> {
+        // Convert time period to Azure date format (YYYY-MM-DD)
+        let start_date = query.time_period.start.format("%Y-%m-%d").to_string();
+        let end_date = query.time_period.end.format("%Y-%m-%d").to_string();
+
+        let date_range = AzureDateRange {
+            start: start_date,
+            end: end_date,
+        };
+
+        // Default to MonthlySummaryReport for now - can be made configurable later
+        let report_type = "MonthlySummaryReport".to_string();
+
+        // Use regions from query as subscription IDs
+        let subscription_list = query.regions.clone();
+
+        // Default carbon scopes - can be made configurable later
+        let carbon_scope_list = vec!["Scope1".to_string(), "Scope3".to_string()];
+
+        Ok(AzureCarbonEmissionReportRequest {
+            report_type,
+            subscription_list,
+            carbon_scope_list,
+            date_range,
+            // Optional fields - set to None for now
+            category_type: None,
+            top_items: None,
+            order_by: None,
+            sort_direction: None,
+            page_size: None,
+            location_list: None,
+            resource_group_url_list: None,
+            resource_type_list: None,
+            skip_token: None,
+        })
+    }
+
+    // Build authorization headers for Azure API requests
+    fn build_headers(&self) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+
+        // Add authorization header
+        let auth_value = format!("Bearer {}", self.config.access_token);
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&auth_value)
+                .map_err(|e| CarbemError::Config(format!("Invalid access token: {}", e)))?,
+        );
+
+        // Add content type
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        Ok(headers)
+    }
+
+    fn build_request_payload(
+        &self,
+        query: &AzureCarbonEmissionReportRequest,
+    ) -> AzureCarbonEmissionReportRequest {
+        // At the moment, does nothing as we are still using only one struct
+        return query.clone();
+    }
+
+    ///Convert Azure emission data to carbem CarbonEmission
+    fn convert_to_carbon_emission(
+        &self,
+        data: &AzureEmissionData,
+        subscription_id: &str,
+        date_range: &AzureDateRange,
+    ) -> CarbonEmission {
+        // Create metadata with Azure-specific information
+        let mut provider_data = serde_json::Map::new();
+        provider_data.insert(
+            "dataType".to_string(),
+            serde_json::Value::String(data.data_type.clone()),
+        );
+        provider_data.insert(
+            "previousMonthEmissions".to_string(),
+            serde_json::Value::Number(
+                serde_json::Number::from_f64(data.previous_month_emissions).unwrap(),
+            ),
+        );
+        provider_data.insert(
+            "monthOverMonthEmissionsChangeRatio".to_string(),
+            serde_json::Value::Number(
+                serde_json::Number::from_f64(data.month_over_month_emissions_change_ratio).unwrap(),
+            ),
+        );
+        provider_data.insert(
+            "monthlyEmissionsChangeValue".to_string(),
+            serde_json::Value::Number(
+                serde_json::Number::from_f64(data.monthly_emissions_change_value).unwrap(),
+            ),
+        );
+
+        // Add date if available
+        if let Some(date) = &data.date {
+            provider_data.insert("date".to_string(), serde_json::Value::String(date.clone()));
+        }
+
+        // Add item name and category type if available (for TopItemsSummaryReport)
+        if let Some(item_name) = &data.item_name {
+            provider_data.insert(
+                "itemName".to_string(),
+                serde_json::Value::String(item_name.clone()),
+            );
+        }
+        if let Some(category_type) = &data.category_type {
+            provider_data.insert(
+                "categoryType".to_string(),
+                serde_json::Value::String(category_type.clone()),
+            );
+        }
+
+        // Create specific time period for this data point if date is provided
+        let specific_time_period = if let Some(date) = &data.date {
+            // Parse the date and create a month-specific time period
+            match DateTime::parse_from_str(
+                &format!("{}T00:00:00+00:00", date),
+                "%Y-%m-%dT%H:%M:%S%z",
+            ) {
+                Ok(start_date) => {
+                    let start = start_date.with_timezone(&Utc);
+                    // Create end of month
+                    let end = if start.month() == 12 {
+                        start
+                            .with_year(start.year() + 1)
+                            .unwrap()
+                            .with_month(1)
+                            .unwrap()
+                    } else {
+                        start.with_month(start.month() + 1).unwrap()
+                    };
+                    TimePeriod { start, end }
+                }
+                Err(_) => {
+                    // Fallback: convert DateRange to TimePeriod using start and end
+                    let start = DateTime::parse_from_str(
+                        &format!("{}T00:00:00+00:00", date_range.start),
+                        "%Y-%m-%dT%H:%M:%S%z",
+                    )
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| {
+                        // Final fallback to a fixed date for testing consistency
+                        DateTime::parse_from_str("2024-01-01T00:00:00+00:00", "%Y-%m-%dT%H:%M:%S%z")
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
+                    });
+                    let end = DateTime::parse_from_str(
+                        &format!("{}T00:00:00+00:00", date_range.end),
+                        "%Y-%m-%dT%H:%M:%S%z",
+                    )
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| {
+                        // Final fallback to a fixed date for testing consistency
+                        DateTime::parse_from_str("2024-01-02T00:00:00+00:00", "%Y-%m-%dT%H:%M:%S%z")
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap())
+                    });
+                    TimePeriod { start, end }
+                }
+            }
+        } else {
+            // Convert DateRange to TimePeriod using start and end
+            let start = DateTime::parse_from_str(
+                &format!("{}T00:00:00+00:00", date_range.start),
+                "%Y-%m-%dT%H:%M:%S%z",
+            )
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| {
+                // Final fallback to a fixed date for testing consistency
+                DateTime::parse_from_str("2024-01-01T00:00:00+00:00", "%Y-%m-%dT%H:%M:%S%z")
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
+            });
+            let end = DateTime::parse_from_str(
+                &format!("{}T00:00:00+00:00", date_range.end),
+                "%Y-%m-%dT%H:%M:%S%z",
+            )
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| {
+                // Final fallback to a fixed date for testing consistency
+                DateTime::parse_from_str("2024-01-02T00:00:00+00:00", "%Y-%m-%dT%H:%M:%S%z")
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap())
+            });
+            TimePeriod { start, end }
+        };
+
+        let metadata = EmissionMetadata {
+            energy_kwh: None,                             // Not provided by Azure API
+            grid_carbon_intensity: data.carbon_intensity, // Use Azure's carbon intensity
+            renewable_percentage: None,                   // Not provided by Azure API
+            provider_data: Some(serde_json::Value::Object(provider_data)),
+        };
+
+        // Use item_name as region if available (for location-based reports), otherwise use subscription_id
+        let region = data
+            .item_name
+            .as_ref()
+            .unwrap_or(&subscription_id.to_string())
+            .clone();
+
+        // Use category_type as service if available, otherwise default to "overall"
+        let service = data
+            .category_type
+            .as_ref()
+            .map(|ct| ct.to_lowercase())
+            .or_else(|| Some("overall".to_string()));
+
+        CarbonEmission {
+            provider: "azure".to_string(),
+            region,
+            service,
+            emissions_kg_co2eq: data.latest_month_emissions,
+            time_period: specific_time_period,
+            metadata: Some(metadata),
+        }
+    }
+
+    async fn request_carbon_emissions(
+        &self,
+        query: &AzureCarbonEmissionReportRequest,
+    ) -> Result<Vec<CarbonEmission>> {
+        let url = format!(
+            "{}/providers/Microsoft.Carbon/carbonEmissionReports?api-version={}",
+            AZURE_MANAGEMENT_BASE_URL, CARBON_API_VERSION
+        );
+
+        let headers = self.build_headers()?;
+        let payload = self.build_request_payload(query);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .headers(headers)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| CarbemError::Http(e))?;
+
+        // Check if request was successful
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(CarbemError::Provider(format!(
+                "Azure API request failed with status {}: {}",
+                status, body
+            )));
+        }
+
+        let azure_response: AzureCarbonEmissionReportResponse =
+            response.json().await.map_err(CarbemError::Http)?;
+
+        // Check for access decisions and collect denied subscriptions info
+        let mut allowed_subscriptions = Vec::new();
+        let mut denied_subscriptions = Vec::new();
+        for decision in &azure_response.subscription_access_decision_list {
+            if decision.decision == "Allowed" {
+                allowed_subscriptions.push(decision.subscription_id.clone());
+                continue;
+            } else {
+                let reason = decision
+                    .denial_reason
+                    .as_ref()
+                    .map(|r| format!(" ({})", r))
+                    .unwrap_or_default();
+                denied_subscriptions.push(format!("{}{}", decision.subscription_id, reason));
+            }
+        }
+
+        // Log denied subscriptions but don't fail the entire request if some subscriptions are allowed
+        if !denied_subscriptions.is_empty() {
+            // If ALL subscriptions are denied, return an error
+            if denied_subscriptions.len() == azure_response.subscription_access_decision_list.len()
+            {
+                return Err(CarbemError::Auth(format!(
+                    "Access denied for all subscriptions: {}",
+                    denied_subscriptions.join(", ")
+                )));
+            }
+            // Otherwise, we can continue with the allowed subscriptions
+        }
+
+        // Convert Azure response to carbem format
+        let mut emissions = Vec::new();
+        for data in azure_response.value {
+            for subscription_id in &allowed_subscriptions {
+                let emission =
+                    self.convert_to_carbon_emission(&data, &subscription_id, &query.date_range);
+                emissions.push(emission);
+            }
+        }
+
+        // Sort emissions by date if available (newest first)
+        emissions.sort_by(|a, b| b.time_period.start.cmp(&a.time_period.start));
+
+        Ok(emissions)
+    }
+}
+
+#[async_trait]
+impl CarbonProvider for AzureProvider {
+    fn name(&self) -> &'static str {
+        "azure"
+    }
+
+    async fn get_emissions(&self, query: &EmissionQuery) -> Result<Vec<CarbonEmission>> {
+        if query.provider != "azure" {
+            return Err(CarbemError::Config(
+                "Query provider must be 'azure' for AzureProvider".to_string(),
+            ));
+        }
+
+        if query.regions.is_empty() {
+            return Err(CarbemError::Config(
+                "At least one subscriptionId must be specified in the query".to_string(),
+            ));
+        }
+
+        // Convert EmissionQuery to Azure request format
+        let azure_request = self.convert_emission_query_to_azure_request(query)?;
+
+        self.request_carbon_emissions(&azure_request).await
+    }
+
+    fn is_configured(&self) -> bool {
+        !self.config.access_token.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{EmissionQuery, TimePeriod};
+    use chrono::{TimeZone, Utc};
+
+    fn create_test_provider() -> AzureProvider {
+        let config = AzureConfig {
+            access_token: "test-token".to_string(),
+        };
+        AzureProvider::new(config).unwrap()
+    }
+
+    fn create_test_emission_query() -> EmissionQuery {
+        EmissionQuery {
+            provider: "azure".to_string(),
+            regions: vec!["00000000-0000-0000-0000-000000000000".to_string()],
+            time_period: TimePeriod {
+                start: Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),
+                end: Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_azure_provider_creation() {
+        let config = AzureConfig {
+            access_token: "test-token".to_string(),
+        };
+        let provider = AzureProvider::new(config).unwrap();
+
+        assert_eq!(provider.name(), "azure");
+        assert!(provider.is_configured());
+    }
+
+    #[test]
+    fn test_azure_provider_not_configured_with_empty_token() {
+        let config = AzureConfig {
+            access_token: "".to_string(),
+        };
+        let provider = AzureProvider::new(config).unwrap();
+
+        assert!(!provider.is_configured());
+    }
+
+    #[test]
+    fn test_convert_emission_query_to_azure_request() {
+        let provider = create_test_provider();
+        let query = create_test_emission_query();
+
+        let azure_request = provider
+            .convert_emission_query_to_azure_request(&query)
+            .unwrap();
+
+        assert_eq!(azure_request.report_type, "MonthlySummaryReport");
+        assert_eq!(
+            azure_request.subscription_list,
+            vec!["00000000-0000-0000-0000-000000000000"]
+        );
+        assert_eq!(azure_request.carbon_scope_list, vec!["Scope1", "Scope3"]);
+        assert_eq!(azure_request.date_range.start, "2024-03-01");
+        assert_eq!(azure_request.date_range.end, "2024-05-01");
+        assert_eq!(azure_request.category_type, None);
+        assert_eq!(azure_request.top_items, None);
+        assert_eq!(azure_request.order_by, None);
+        assert_eq!(azure_request.sort_direction, None);
+        assert_eq!(azure_request.page_size, None);
+    }
+
+    #[test]
+    fn test_build_headers() {
+        let provider = create_test_provider();
+        let headers = provider.build_headers().unwrap();
+
+        assert!(headers.contains_key("authorization"));
+        assert!(headers.contains_key("content-type"));
+
+        let auth_header = headers.get("authorization").unwrap().to_str().unwrap();
+        assert_eq!(auth_header, "Bearer test-token");
+
+        let content_type = headers.get("content-type").unwrap().to_str().unwrap();
+        assert_eq!(content_type, "application/json");
+    }
+
+    #[test]
+    fn test_build_headers_invalid_token() {
+        let config = AzureConfig {
+            access_token: "invalid\ntoken".to_string(),
+        };
+        let provider = AzureProvider::new(config).unwrap();
+
+        let result = provider.build_headers();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid access token"));
+    }
+
+    #[test]
+    fn test_build_request_payload() {
+        let provider = create_test_provider();
+        let query = create_test_emission_query();
+
+        let azure_request = provider
+            .convert_emission_query_to_azure_request(&query)
+            .unwrap();
+        let payload = provider.build_request_payload(&azure_request);
+
+        // Since build_request_payload currently just clones the input, they should be identical
+        assert_eq!(payload.report_type, azure_request.report_type);
+        assert_eq!(payload.subscription_list, azure_request.subscription_list);
+        assert_eq!(payload.carbon_scope_list, azure_request.carbon_scope_list);
+        assert_eq!(payload.date_range.start, azure_request.date_range.start);
+        assert_eq!(payload.date_range.end, azure_request.date_range.end);
+    }
+
+    #[test]
+    fn test_convert_to_carbon_emission_basic() {
+        let provider = create_test_provider();
+        let date_range = AzureDateRange {
+            start: "2024-03-01".to_string(),
+            end: "2024-05-01".to_string(),
+        };
+
+        let azure_data = AzureEmissionData {
+            data_type: "MonthlySummaryData".to_string(),
+            latest_month_emissions: 0.1,
+            previous_month_emissions: 0.05,
+            month_over_month_emissions_change_ratio: 1.0,
+            monthly_emissions_change_value: 0.05,
+            date: Some("2024-05-01".to_string()),
+            carbon_intensity: Some(22.0),
+            item_name: None,
+            category_type: None,
+        };
+
+        let emission =
+            provider.convert_to_carbon_emission(&azure_data, "test-subscription", &date_range);
+
+        assert_eq!(emission.provider, "azure");
+        assert_eq!(emission.region, "test-subscription");
+        assert_eq!(emission.service, Some("overall".to_string()));
+        assert_eq!(emission.emissions_kg_co2eq, 0.1);
+        assert!(emission.metadata.is_some());
+
+        let metadata = emission.metadata.unwrap();
+        assert_eq!(metadata.grid_carbon_intensity, Some(22.0));
+        assert!(metadata.provider_data.is_some());
+
+        let provider_data = metadata.provider_data.unwrap();
+        assert_eq!(provider_data["dataType"], "MonthlySummaryData");
+        assert_eq!(provider_data["date"], "2024-05-01");
+        assert_eq!(provider_data["previousMonthEmissions"], 0.05);
+        assert_eq!(provider_data["monthOverMonthEmissionsChangeRatio"], 1.0);
+        assert_eq!(provider_data["monthlyEmissionsChangeValue"], 0.05);
+    }
+
+    #[test]
+    fn test_convert_to_carbon_emission_with_item_name() {
+        let provider = create_test_provider();
+        let date_range = AzureDateRange {
+            start: "2024-03-01".to_string(),
+            end: "2024-05-01".to_string(),
+        };
+
+        let azure_data = AzureEmissionData {
+            data_type: "TopItemsSummaryData".to_string(),
+            latest_month_emissions: 0.1,
+            previous_month_emissions: 0.05,
+            month_over_month_emissions_change_ratio: 1.0,
+            monthly_emissions_change_value: 0.05,
+            date: None,
+            carbon_intensity: None,
+            item_name: Some("east us".to_string()),
+            category_type: Some("Location".to_string()),
+        };
+
+        let emission =
+            provider.convert_to_carbon_emission(&azure_data, "test-subscription", &date_range);
+
+        assert_eq!(emission.provider, "azure");
+        assert_eq!(emission.region, "east us"); // Should use item_name as region
+        assert_eq!(emission.service, Some("location".to_string())); // Should use category_type (lowercased)
+        assert_eq!(emission.emissions_kg_co2eq, 0.1);
+
+        let metadata = emission.metadata.unwrap();
+        let provider_data = metadata.provider_data.unwrap();
+        assert_eq!(provider_data["itemName"], "east us");
+        assert_eq!(provider_data["categoryType"], "Location");
+    }
+
+    #[test]
+    fn test_convert_to_carbon_emission_with_date_parsing() {
+        let provider = create_test_provider();
+        let date_range = AzureDateRange {
+            start: "2024-03-01".to_string(),
+            end: "2024-05-01".to_string(),
+        };
+
+        let azure_data = AzureEmissionData {
+            data_type: "MonthlySummaryData".to_string(),
+            latest_month_emissions: 0.1,
+            previous_month_emissions: 0.05,
+            month_over_month_emissions_change_ratio: 1.0,
+            monthly_emissions_change_value: 0.05,
+            date: Some("2024-05-01".to_string()),
+            carbon_intensity: Some(22.0),
+            item_name: None,
+            category_type: None,
+        };
+
+        let emission =
+            provider.convert_to_carbon_emission(&azure_data, "test-subscription", &date_range);
+
+        // Check that the time period was created from the date (May 1 to June 1)
+        let expected_start = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+        let expected_end = Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap();
+
+        assert_eq!(emission.time_period.start, expected_start);
+        assert_eq!(emission.time_period.end, expected_end);
+    }
+
+    #[test]
+    fn test_get_emissions_wrong_provider() {
+        let provider = create_test_provider();
+        let mut query = create_test_emission_query();
+        query.provider = "aws".to_string();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(provider.get_emissions(&query));
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Query provider must be 'azure'"));
+    }
+
+    #[test]
+    fn test_get_emissions_no_regions() {
+        let provider = create_test_provider();
+        let mut query = create_test_emission_query();
+        query.regions = vec![];
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(provider.get_emissions(&query));
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("At least one subscriptionId must be specified"));
+    }
+
+    #[test]
+    fn test_month_end_calculation_december() {
+        let provider = create_test_provider();
+        let date_range = AzureDateRange {
+            start: "2024-12-01".to_string(),
+            end: "2024-12-31".to_string(),
+        };
+
+        let azure_data = AzureEmissionData {
+            data_type: "MonthlySummaryData".to_string(),
+            latest_month_emissions: 0.1,
+            previous_month_emissions: 0.05,
+            month_over_month_emissions_change_ratio: 1.0,
+            monthly_emissions_change_value: 0.05,
+            date: Some("2024-12-01".to_string()),
+            carbon_intensity: None,
+            item_name: None,
+            category_type: None,
+        };
+
+        let emission =
+            provider.convert_to_carbon_emission(&azure_data, "test-subscription", &date_range);
+
+        // December should roll over to January of the next year
+        let expected_start = Utc.with_ymd_and_hms(2024, 12, 1, 0, 0, 0).unwrap();
+        let expected_end = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+
+        assert_eq!(emission.time_period.start, expected_start);
+        assert_eq!(emission.time_period.end, expected_end);
+    }
+
+    #[test]
+    fn test_overall_summary_data_conversion() {
+        let provider = create_test_provider();
+        let date_range = AzureDateRange {
+            start: "2024-03-01".to_string(),
+            end: "2024-05-01".to_string(),
+        };
+
+        let azure_data = AzureEmissionData {
+            data_type: "OverallSummaryData".to_string(),
+            latest_month_emissions: 0.1,
+            previous_month_emissions: 0.05,
+            month_over_month_emissions_change_ratio: 1.0,
+            monthly_emissions_change_value: 0.05,
+            date: None,
+            carbon_intensity: None,
+            item_name: None,
+            category_type: None,
+        };
+
+        let emission =
+            provider.convert_to_carbon_emission(&azure_data, "test-subscription", &date_range);
+
+        assert_eq!(emission.provider, "azure");
+        assert_eq!(emission.region, "test-subscription"); // Should use subscription_id when no item_name
+        assert_eq!(emission.service, Some("overall".to_string())); // Should default to "overall"
+        assert_eq!(emission.emissions_kg_co2eq, 0.1);
+
+        // Should use the original date range when no specific date is provided
+        let expected_start = Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap();
+        let expected_end = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+
+        assert_eq!(emission.time_period.start, expected_start);
+        assert_eq!(emission.time_period.end, expected_end);
+
+        let metadata = emission.metadata.unwrap();
+        let provider_data = metadata.provider_data.unwrap();
+        assert_eq!(provider_data["dataType"], "OverallSummaryData");
+    }
+
+    #[tokio::test]
+    #[ignore] // Ignore by default as this requires a real Azure token
+    async fn test_get_emissions_integration() {
+        // This test would require actual Azure credentials
+        // Only run when AZURE_ACCESS_TOKEN environment variable is set
+        if let Ok(access_token) = std::env::var("AZURE_ACCESS_TOKEN") {
+            let config = AzureConfig { access_token };
+            let provider = AzureProvider::new(config).unwrap();
+
+            let query = EmissionQuery {
+                provider: "azure".to_string(),
+                regions: vec!["your-subscription-id".to_string()],
+                time_period: TimePeriod {
+                    start: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+                    end: Utc.with_ymd_and_hms(2024, 2, 1, 0, 0, 0).unwrap(),
+                },
+            };
+
+            let result = provider.get_emissions(&query).await;
+            assert!(result.is_ok());
+        }
+    }
+}

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod models;

--- a/src/providers/azure/models.rs
+++ b/src/providers/azure/models.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+
+// Sort direction for ItemDetailsReport
+#[derive(Debug, Clone)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl SortDirection {
+    fn as_string(&self) -> String {
+        match self {
+            SortDirection::Asc => "Asc".to_string(),
+            SortDirection::Desc => "Desc".to_string(),
+        }
+    }
+}
+
+// Date range for the carbon emission report
+#[derive(Debug, Clone, Serialize)]
+pub struct AzureDateRange {
+    pub start: String, // Format: "YYYY-MM-DD"
+    pub end: String,   // Format: "YYYY-MM-DD"
+}
+
+// Report types supported by Azure Carbon API
+#[derive(Debug, Clone)]
+pub enum AzureReportType {
+    OverallSummary,
+    MonthlySummary,
+    TopItemsSummary,
+    TopItemsMonthlySummary,
+    ItemDetails,
+}
+
+impl AzureReportType {
+    fn as_string(&self) -> String {
+        match self {
+            AzureReportType::OverallSummary => "OverallSummary".to_string(),
+            AzureReportType::MonthlySummary => "MonthlySummary".to_string(),
+            AzureReportType::TopItemsSummary => "TopItemsSummary".to_string(),
+            AzureReportType::TopItemsMonthlySummary => "TopItemsMonthlySummary".to_string(),
+            AzureReportType::ItemDetails => "ItemDetails".to_string(),
+        }
+    }
+}
+// Azure Carbon Emission Reports request payload
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AzureCarbonEmissionReportRequest {
+    // Mandatory fields for all report types
+    pub(super) carbon_scope_list: Vec<String>,
+    pub(super) date_range: AzureDateRange,
+    pub(super) report_type: String,
+    pub(super) subscription_list: Vec<String>,
+    // Mandatory field for ItemDetailsQueryFilter, TopItemsMonthlySummaryReportQueryFilter, TopItemsSummaryReportQueryFilter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) category_type: Option<String>,
+    // Mandatory fields for ItemDetailsQueryFilter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) order_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) page_size: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) sort_direction: Option<String>,
+    // Mandatory fields for TopItemsMonthlySummaryReportQueryFilter, TopItemsSummaryReportQueryFilter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) top_items: Option<i32>,
+    // Optional fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) location_list: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) resource_group_url_list: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) resource_type_list: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) skip_token: Option<String>,
+}
+
+// Subscription access decision in Azure response
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AzureSubscriptionAccessDecision {
+    pub(super) subscription_id: String,
+    pub(super) decision: String,
+    #[serde(default)]
+    pub(super) denial_reason: Option<String>,
+}
+
+// Emission data from Azure API
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AzureEmissionData {
+    pub(super) data_type: String,
+    pub(super) latest_month_emissions: f64,
+    pub(super) previous_month_emissions: f64,
+    pub(super) month_over_month_emissions_change_ratio: f64,
+    pub(super) monthly_emissions_change_value: f64,
+    #[serde(default)]
+    pub(super) date: Option<String>, // Format: "YYYY-MM-DD", for MonthlySummaryReport
+    #[serde(default)]
+    pub(super) carbon_intensity: Option<f64>, // For MonthlySummaryReport
+    #[serde(default)]
+    pub(super) item_name: Option<String>, // For TopItemsSummaryReport, TopItemsMonthlySummaryReport & ItemDetailsReport(e.g., "east us", "west us")
+    #[serde(default)]
+    pub(super) category_type: Option<String>, // For TopItemsSummaryReport, TopItemsMonthlySummaryReport & ItemDetailsReport (e.g., "Location")
+}
+
+/// Azure API response for carbon emission reports
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AzureCarbonEmissionReportResponse {
+    pub(super) subscription_access_decision_list: Vec<AzureSubscriptionAccessDecision>,
+    pub(super) value: Vec<AzureEmissionData>,
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,10 +1,9 @@
 //! Cloud provider modules for carbon emission data retrieval
 
-pub mod aws;
 pub mod azure;
-pub mod gcp;
 
-use crate::{Result, CarbonEmission, EmissionQuery};
+use crate::error::Result;
+use crate::models::{CarbonEmission, EmissionQuery};
 use async_trait::async_trait;
 
 /// Trait that all carbon emission providers must implement
@@ -12,13 +11,10 @@ use async_trait::async_trait;
 pub trait CarbonProvider {
     /// Get the provider name
     fn name(&self) -> &'static str;
-    
-    /// Get supported regions for this provider
-    async fn get_regions(&self) -> Result<Vec<String>>;
-    
+
     /// Query carbon emissions for the given parameters
     async fn get_emissions(&self, query: &EmissionQuery) -> Result<Vec<CarbonEmission>>;
-    
+
     /// Check if the provider is properly configured
     fn is_configured(&self) -> bool;
 }


### PR DESCRIPTION
This PR adds Azure support to the carbem library for retrieving carbon emission data from cloud providers. The implementation includes Azure-specific models, client implementation, and updates to the core library structure.

*  Add complete Azure Carbon Emission Reports API integration with models and client
* Refactor library architecture to focus on client module exports
* Update configuration to support environment variable loading for Azure credentials
